### PR TITLE
fix(drawer): add sticky positioning and prevent scroll when opened

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -2,7 +2,6 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 import { links } from '../data/navLinks';
 import { Transition, TransitionChild } from '@headlessui/react';
 import { ThemeToggle } from './ThemeToggle';
-
 type DrawerProps = {
   open: boolean;
   onClose: () => void;
@@ -15,7 +14,7 @@ export const Drawer = ({ open, onClose }: DrawerProps) => {
     <div
       className={`absolute top-0  bg-surface min-h-screen min-w-screen -translate-y-full sm:hidden z-50 ${
         open ? 'translate-y-0' : '-translate-y-full'
-      } transition-all duration-700 p-3 gap-10 flex flex-col`}
+      } transition-all duration-700 p-3 gap-10 flex flex-col sticky`}
     >
       <div className=" flex justify-between">
         <button onClick={onClose}>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -2,6 +2,8 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 import { links } from '../data/navLinks';
 import { Transition, TransitionChild } from '@headlessui/react';
 import { ThemeToggle } from './ThemeToggle';
+import { useEffect } from 'react';
+
 type DrawerProps = {
   open: boolean;
   onClose: () => void;
@@ -9,6 +11,15 @@ type DrawerProps = {
 
 export const Drawer = ({ open, onClose }: DrawerProps) => {
   const delays = ['delay-[300ms]', 'delay-[600ms]', 'delay-[900ms]'];
+
+  useEffect(() => {
+    if (open) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = '';
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
 
   return (
     <div


### PR DESCRIPTION
### changes
- Added sticky positioning
-  prevented scrolling when opened

### why
These changes allow the users to interact with the navbar menu options anywhere on the page and prevent background scrolling for a better, overall smother experience.